### PR TITLE
Fix webadmin by adding admin password to KFGame.ini file.

### DIFF
--- a/kf2_functions.sh
+++ b/kf2_functions.sh
@@ -96,6 +96,7 @@ function load_config() {
     ## Now we edit the config files to set the config
     sed -i "s/^GameLength=.*/GameLength=$KF_GAME_LENGTH\r/" "${HOME}/kf2server/KFGame/Config/LinuxServer-KFGame.ini"
     sed -i "s/^ServerName=.*/ServerName=$KF_SERVER_NAME\r/" "${HOME}/kf2server/KFGame/Config/LinuxServer-KFGame.ini"
+    sed -i "s/^AdminPassword.*/AdminPassword=$KF_ADMIN_PASS\r/" "${HOME}/kf2server/KFGame/Config/LinuxServer-KFGame.ini"
     sed -i "s/^bEnabled=.*/bEnabled=$KF_ENABLE_WEB\r/" "${HOME}/kf2server/KFGame/Config/KFWeb.ini"
     [[ "${KF_DISABLE_TAKEOVER}" == 'true' ]] && sed -i 's/^bUsedForTakeover=.*/bUsedForTakeover=FALSE'"\r"'/' "${HOME}/kf2server/KFGame/Config/LinuxServer-KFEngine.ini"
     sed -i "s/^DownloadManagers=IpDrv.HTTPDownload/DownloadManagers=OnlineSubsystemSteamworks.SteamWorkshopDownload/" "${HOME}/kf2server/KFGame/Config/LinuxServer-KFEngine.ini"


### PR DESCRIPTION
When I try to use webadmin after setting up the server I am presented with the following error message: 
![kf2 webadmin config error](https://user-images.githubusercontent.com/354226/50550719-3a6ea400-0c2a-11e9-9e0e-598d4dbbae30.PNG)

This PR just writes the key in the error message with the appropriate value.  I was then able to connect and sign in after a fresh install.
