### PR TITLE
Multihome Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Variables
 | `KF_ENABLE_WEB`       | `false`           | A boolean toggle for the web interface hosted on the KF_WEBADMIN_PORT (default 8080) If setting this to true, it's recommended you change the `KF_ADMIN_PASS` variable too.                                |
 | `KF_WEBADMIN_PORT`    | `8080`            | The port used to access the web admin interface.                                                                                                                                                           |
 | `KF_DISABLE_TAKEOVER` | `false`           | Allows the server to be used by other players looking to create a private game when the server is uninhabited.                                                                                             |
+| `MULTIHOME_IP` | `''` | Sets the IP to run the server on in cases where it has been assigned multiple public IPs. |
 
 
 Running multiple servers

--- a/kf2_functions.sh
+++ b/kf2_functions.sh
@@ -110,6 +110,7 @@ function launch() {
     cmd+="$KF_MAP?Game=KFGameContent.KFGameInfo_$KF_GAME_MODE"
     cmd+="?Difficulty=$KF_DIFFICULTY"
     cmd+="?AdminPassword=$KF_ADMIN_PASS"
+    [[ -z "$MULTIHOME_IP" ]] || cmd+="?Multihome=${MULTIHOME_IP}"
     [[ -z "$KF_MUTATORS" ]] || cmd+="?Mutator=$KF_MUTATORS"
     [[ -z "$KF_GAME_PASS" ]] || cmd+="?GamePassword=$KF_GAME_PASS"
     cmd+=" -Port=$KF_PORT"


### PR DESCRIPTION
Adding multihome support alongside relevant documentation, used in cases where a server has multiple public IPs.