### PR TITLE
Takeover Fix

### DIFF
--- a/kf2_functions.sh
+++ b/kf2_functions.sh
@@ -97,7 +97,11 @@ function load_config() {
     sed -i "s/^GameLength=.*/GameLength=$KF_GAME_LENGTH\r/" "${HOME}/kf2server/KFGame/Config/LinuxServer-KFGame.ini"
     sed -i "s/^ServerName=.*/ServerName=$KF_SERVER_NAME\r/" "${HOME}/kf2server/KFGame/Config/LinuxServer-KFGame.ini"
     sed -i "s/^bEnabled=.*/bEnabled=$KF_ENABLE_WEB\r/" "${HOME}/kf2server/KFGame/Config/KFWeb.ini"
-    [[ "${KF_DISABLE_TAKEOVER}" == 'true' ]] && sed -i 's/^bUsedForTakeover=.*/bUsedForTakeover=FALSE'"\r"'/' "${HOME}/kf2server/KFGame/Config/LinuxServer-KFEngine.ini"
+    if [[ "${KF_DISABLE_TAKEOVER}" == 'true' ]]; then 
+      sed -i 's/^bUsedForTakeover=.*/bUsedForTakeover=FALSE'"\r"'/' "${HOME}/kf2server/KFGame/Config/LinuxServer-KFEngine.ini"
+    else
+      sed -i 's/^bUsedForTakeover=.*/bUsedForTakeover=TRUE/' "${HOME}/kf2server/KFGame/Config/LinuxServer-KFEngine.ini"
+    fi
     sed -i "s/^DownloadManagers=IpDrv.HTTPDownload/DownloadManagers=OnlineSubsystemSteamworks.SteamWorkshopDownload/" "${HOME}/kf2server/KFGame/Config/LinuxServer-KFEngine.ini"
 
 }

--- a/kf2_functions.sh
+++ b/kf2_functions.sh
@@ -98,9 +98,9 @@ function load_config() {
     sed -i "s/^ServerName=.*/ServerName=$KF_SERVER_NAME\r/" "${HOME}/kf2server/KFGame/Config/LinuxServer-KFGame.ini"
     sed -i "s/^bEnabled=.*/bEnabled=$KF_ENABLE_WEB\r/" "${HOME}/kf2server/KFGame/Config/KFWeb.ini"
     if [[ "${KF_DISABLE_TAKEOVER}" == 'true' ]]; then 
-      sed -i 's/^bUsedForTakeover=.*/bUsedForTakeover=FALSE'"\r"'/' "${HOME}/kf2server/KFGame/Config/LinuxServer-KFEngine.ini"
+      sed -i "s/^bUsedForTakeover=.*/bUsedForTakeover=FALSE\r/" "${HOME}/kf2server/KFGame/Config/LinuxServer-KFEngine.ini"
     else
-      sed -i 's/^bUsedForTakeover=.*/bUsedForTakeover=TRUE/' "${HOME}/kf2server/KFGame/Config/LinuxServer-KFEngine.ini"
+      sed -i "s/^bUsedForTakeover=.*/bUsedForTakeover=TRUE\r/" "${HOME}/kf2server/KFGame/Config/LinuxServer-KFEngine.ini"
     fi
     sed -i "s/^DownloadManagers=IpDrv.HTTPDownload/DownloadManagers=OnlineSubsystemSteamworks.SteamWorkshopDownload/" "${HOME}/kf2server/KFGame/Config/LinuxServer-KFEngine.ini"
 


### PR DESCRIPTION
Previously it was only possible to disable takeover, not to enable it since`sed` would only ever set the flag to false.