### PR TITLE
Fix libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,14 @@ FROM ubuntu:xenial
 
 RUN \
 	apt-get -y update && \
-	apt-get -y install wget lib32gcc1 && \
+	apt-get -y install wget lib32gcc1 libcurl4-openssl-dev libssl1.0.0 libssl-dev openssl && \
 	apt-get clean && \
 	find /var/lib/apt/lists -type f | xargs rm -vf
+
+# Create link to fix ssl and crypto libraries
+RUN \
+	ln -s /lib/x86_64-linux-gnu/libssl.so.1.0.0 /lib/x86_64-linux-gnu/libssl.so.1.1 && \
+	ln -s /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.1
 
 RUN useradd -m steam
 


### PR DESCRIPTION
Hi!

I've found some issues deploying this docker image. The issue that i'm having is that the KF2 binary requires some SSL libraries that's currently not installed inside the image.

In order to fix those errors, I've made a Dockerfile on top of your image with this content:

```
...
RUN apt-get purge --auto-remove openssl -y && apt-get install libcurl4-openssl-dev  libssl1.0.0 libssl-dev openssl -y
RUN ln -s /lib/x86_64-linux-gnu/libssl.so.1.0.0 /lib/x86_64-linux-gnu/libssl.so.1.1
RUN ln -s /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.1
...
```
With those changes I've got the server running perfectly fine, even with a lot of players and no crashes in the last 24h (since I've running the server).

I've adapted those changes to your Dockerfile (see diff).

Thanks for the image and keep killing zeds! 🧟 
