### PR TITLE
Fixes for New Server Binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:eoan
+FROM ubuntu:focal
 
 RUN \
 	apt-get -y update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:xenial
+FROM ubuntu:eoan
 
 RUN \
 	apt-get -y update && \
-	apt-get -y install wget lib32gcc1 && \
+	apt-get -y install wget lib32gcc1 libcurl4 && \
 	apt-get clean && \
 	find /var/lib/apt/lists -type f | xargs rm -vf
 


### PR DESCRIPTION
The new server binaries released a few days ago require a couple of packages, one of which (libssl 1.1) was not available for repo download on Xenial officially. Hence, the Dockerfile has been updated to use Eoan, the latest  Ubuntu image, in order to allow the missing package to be installed. Additionally, libcurl4 is included in the apt install list within Dockerfile in order to install libcurl.so.4 which is required to run the game.

Weird changes tbh, not really sure why that's not done by steamcmd but there ya go....

It is feasible that previous versions of the server binaries might not work with such a change but I'm doubtful considering the packages previously in the apt install list were just to download the steamcmd client. I did update the existing server install on my machine so maybe there's some difference in the install process on a fresh build?